### PR TITLE
base poll command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@ mod commands;
 use poise::serenity_prelude as serenity;
 use std::{
     collections::HashMap,
-    env::var,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -43,7 +42,7 @@ async fn main() {
     // FrameworkOptions contains all of poise's configuration option in one struct
     // Every option can be omitted to use its default value
     let options = poise::FrameworkOptions {
-        commands: vec![commands::help(), commands::ping(), commands::vote(), commands::getvotes()],
+        commands: vec![commands::help(), commands::ping(), commands::vote(), commands::getvotes(), commands::poll()],
         prefix_options: poise::PrefixFrameworkOptions {
             prefix: Some("!".into()),
             edit_tracker: Some(Arc::new(poise::EditTracker::for_timespan(


### PR DESCRIPTION
This is just the base for it. It's syntax is like this:
!poll
:emote1: option name
:emote2: option name
.
.
.
and the bot will mimic what they say, and add reactions accordingly.
Picture: ![](https://gyazo.com/de3bf0cca641759421b76bd79e9c6cf7.png)